### PR TITLE
Updated esl5on5.cfg after bug.

### DIFF
--- a/some-files/esl5on5.cfg
+++ b/some-files/esl5on5.cfg
@@ -114,9 +114,6 @@ sv_logecho 1					// Echo log information to the console.
 sv_logfile 1					// Log server information in the log file.
 sv_logflush 0					// Flush the log file to disk on each write (slow).
 sv_logsdir logfiles                             // Folder in the game directory where server logs will be stored.
-sv_maxrate 0					// min. 0.000000 max. 30000.000000 replicated  Max bandwidth rate allowed on server, 0 == unlimited
-sv_mincmdrate 30				// This sets the minimum value for cl_cmdrate. 0 == unlimited.
-sv_minrate 20000				// Min bandwidth rate allowed on server, 0 == unlimited
 sv_competitive_minspec 1                        // Enable to force certain client convars to minimum/maximum values to help prevent competitive advantages.
 sv_competitive_official_5v5 1			// Enable to force the server to show 5v5 scoreboards and allows spectators to see characters through walls.
 sv_pausable 1                                   // Is the server pausable.


### PR DESCRIPTION
Commands founded (and now removed after lags!)

This COMMANDS IS NO LONGER ON OUR FILE!
sv_maxrate 0					// min. 0.000000 max. 30000.000000 replicated  Max bandwidth rate allowed on server, 0 == unlimited
sv_mincmdrate 30				// This sets the minimum value for cl_cmdrate. 0 == unlimited.
sv_minrate 20000				// Min bandwidth rate allowed on server, 0 == unlimited